### PR TITLE
I believe it should read district_margins.csv

### DIFF
--- a/wrangling/README.md
+++ b/wrangling/README.md
@@ -59,7 +59,7 @@ is uncontested, the margin should be "100", in that the percentage
 difference between the first place candidate and the second is 100.  
 
     $ python districts.py
-    $ head district_totals.csv
+    $ head district_margins.csv
     STATE,DISTRICT,MARGIN
     Arizona,2,0.07000000000000028
     California,7,0.7999999999999972

--- a/wrangling/README.md
+++ b/wrangling/README.md
@@ -70,7 +70,7 @@ difference between the first place candidate and the second is 100.
     Washington,4,1.6200000000000045
     Texas,23,2.1000000000000014
     Iowa,1,2.280000000000001
-    $ tail district_totals.csv
+    $ tail district_margins.csv
     Georgia,3,100.0
     Georgia,14,100.0
     Florida,25,100


### PR DESCRIPTION
I think it should read district_margins.csv instead of district_totals.csv on the readme. Because in the homework python file we write to
  output = DictWriter(open("district_margins.csv", 'w'), fieldnames=kHEADER)

"district_margins.csv"
