### PR TITLE
The test_margins testcase should have a key, not an indicy

### DIFF
--- a/wrangling/tests.py
+++ b/wrangling/tests.py
@@ -28,7 +28,7 @@ class TestDistrictMargins(unittest.TestCase):
 
     def test_margins(self):
         lines = list(DictReader(kALASKA))
-        self.assertAlmostEqual(10.0, district_margins(lines)[0])
+        self.assertAlmostEqual(10.0, district_margins(lines)['0'])
 
     def test_states(self):
         lines = list(DictReader(kALASKA))


### PR DESCRIPTION
In districts.py it specifies that the district_margins function should return a dictionary, not a list.
